### PR TITLE
Fix Ubuntu locale install path

### DIFF
--- a/cmake/ObsPluginHelpers.cmake
+++ b/cmake/ObsPluginHelpers.cmake
@@ -627,11 +627,7 @@ else()
     endif()
 
     # Add resources from data directory
-    if(OS_LINUX)
-      setup_target_resources(${target} ${target})
-    else()
-      setup_target_resources(${target} obs-plugins/${target})
-    endif()
+    setup_target_resources(${target} obs-plugins/${target})
 
     # Set up plugin for testing in available OBS build on Windows
     if(OS_WINDOWS AND DEFINED OBS_BUILD_DIR)


### PR DESCRIPTION
Fixes the install path for Ubuntu 22.04.1 for locale files: `/usr/share/obs/obs-plugins/obs-text-slideshow/locale/`